### PR TITLE
fix(issue-74): resolve brittle test paths causing CI failure

### DIFF
--- a/packages/truth-engine/src/engine.test.ts
+++ b/packages/truth-engine/src/engine.test.ts
@@ -10,14 +10,19 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TruthEngine } from './engine.js';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { rm, mkdir, readdir, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 
 describe('TruthEngine: Bake & Promotion', () => {
+    // High-Rigor: Use package-relative paths for test artifacts
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const pkgRoot = join(__dirname, '..');
+    const TEST_DB = join(pkgRoot, 'data', 'test_bake.db');
+    const STAGING_DIR = join(pkgRoot, '.artifacts', 'test_staging');
+
     let engine: TruthEngine;
-    const TEST_DB = 'data/test_bake.db';
-    const STAGING_DIR = '.artifacts/test_staging';
 
     beforeEach(async () => {
         if (existsSync(TEST_DB)) await rm(TEST_DB);
@@ -153,7 +158,7 @@ describe('TruthEngine: Bake & Promotion', () => {
     });
 
     it('test_should_load_dialects_from_custom_env_path', async () => {
-        const customDir = join(process.cwd(), '.artifacts', 'custom_patterns');
+        const customDir = join(pkgRoot, '.artifacts', 'custom_patterns');
         const { mkdirSync, writeFileSync, existsSync, rmSync } = await import('node:fs');
         if (!existsSync(customDir)) mkdirSync(customDir, { recursive: true });
         
@@ -170,7 +175,8 @@ describe('TruthEngine: Bake & Promotion', () => {
         const originalEnv = process.env.PKD_PATTERN_DIR;
         process.env.PKD_PATTERN_DIR = customDir;
         
-        const customEngine = new TruthEngine('data/custom_test.db');
+        const customEnvDb = join(pkgRoot, 'data', 'custom_test.db');
+        const customEngine = new TruthEngine(customEnvDb);
         await customEngine.init();
         
         const result = await (customEngine as any).normalizer.normalize(1, 'CustomMfr', 'SUCCESS', 'https://test.com');
@@ -180,7 +186,7 @@ describe('TruthEngine: Bake & Promotion', () => {
         customEngine.close();
         process.env.PKD_PATTERN_DIR = originalEnv;
         rmSync(customDir, { recursive: true, force: true });
-        if (existsSync('data/custom_test.db')) rmSync('data/custom_test.db');
+        if (existsSync(customEnvDb)) rmSync(customEnvDb);
     });
 });
 

--- a/packages/truth-engine/src/engine.test.ts
+++ b/packages/truth-engine/src/engine.test.ts
@@ -5,7 +5,7 @@
  * Author: Richard D. (https://github.com/iamrichardd)
  * License: FSL-1.1 (See LICENSE file for details)
  * Purpose: Atomic verification of the Bake Engine and Registry Promotion.
- * Traceability: Issue #53 - ETL Bake
+ * Traceability: Issue #53 - ETL Bake, Issue #74
  * ======================================================================== */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -40,6 +40,10 @@ describe('TruthEngine: Bake & Promotion', () => {
         if (existsSync(STAGING_DIR)) await rm(STAGING_DIR, { recursive: true, force: true });
     });
 
+    /**
+     * Why: Verifies the "Promotion" logic where a successful forensic normalization
+     * results in a new entry in the SQLite equipment registry.
+     */
     it('test_should_promote_to_registry_when_normalization_succeeds', async () => {
         const db = (engine as any)._db;
         db.prepare("INSERT INTO resources (mfr_id, resource_type, uri, sync_state) VALUES (1, 'PDF', 'https://www.frymaster.com/manual.pdf', 'STALE')").run();
@@ -75,6 +79,10 @@ describe('TruthEngine: Bake & Promotion', () => {
         expect(registryEntry.category).toBe("Fryers");
     });
 
+    /**
+     * Why: Ensures that incoming manufacturer data updates existing registry entries
+     * (matching by SKU) instead of creating duplicate records.
+     */
     it('test_should_replace_existing_sku_when_updated_data_arrives', async () => {
         const db = (engine as any)._db;
         db.prepare("INSERT INTO resources (mfr_id, resource_type, uri, sync_state) VALUES (1, 'PDF', 'https://www.frymaster.com/manual.pdf', 'STALE')").run();
@@ -102,6 +110,10 @@ describe('TruthEngine: Bake & Promotion', () => {
         expect(entry.name).toBe("New Fryer");
     });
 
+    /**
+     * Why: Core ETL verification. Confirms that the SQLite registry is correctly 
+     * transformed ("baked") into sharded JSON files for distribution to the CDN.
+     */
     it('test_should_bake_sharded_json_when_registry_is_populated', async () => {
         const db = (engine as any)._db;
         db.prepare("INSERT INTO resources (mfr_id, resource_type, uri, sync_state) VALUES (1, 'PDF', 'https://www.frymaster.com/manual.pdf', 'STALE')").run();
@@ -147,6 +159,10 @@ describe('TruthEngine: Bake & Promotion', () => {
         expect(content.parameters.PKD_Voltage).toBe('208V');
     });
 
+    /**
+     * Why: Confirms that the bake process is idempotent and clean, removing any
+     * stale artifacts from previous runs before generating new ones.
+     */
     it('test_should_perform_atomic_wipe_before_bake', async () => {
         await mkdir(STAGING_DIR, { recursive: true });
         const zombieFile = join(STAGING_DIR, 'zombie.json');
@@ -157,6 +173,10 @@ describe('TruthEngine: Bake & Promotion', () => {
         expect(existsSync(zombieFile)).toBe(false);
     });
 
+    /**
+     * Why: Verifies that the Truth Engine respects environmental overrides for pattern
+     * discovery. This is critical for regional deployments (e.g., es-MX) and local dev.
+     */
     it('test_should_load_dialects_from_custom_env_path', async () => {
         const customDir = join(pkgRoot, '.artifacts', 'custom_patterns');
         const { mkdirSync, writeFileSync, existsSync, rmSync } = await import('node:fs');
@@ -173,20 +193,23 @@ describe('TruthEngine: Bake & Promotion', () => {
         writeFileSync(join(customDir, 'custom.json'), JSON.stringify(dialect));
 
         const originalEnv = process.env.PKD_PATTERN_DIR;
-        process.env.PKD_PATTERN_DIR = customDir;
-        
         const customEnvDb = join(pkgRoot, 'data', 'custom_test.db');
-        const customEngine = new TruthEngine(customEnvDb);
-        await customEngine.init();
-        
-        const result = await (customEngine as any).normalizer.normalize(1, 'CustomMfr', 'SUCCESS', 'https://test.com');
-        expect(result.status).toBe('HEALTHY');
-        
-        // Cleanup
-        customEngine.close();
-        process.env.PKD_PATTERN_DIR = originalEnv;
-        rmSync(customDir, { recursive: true, force: true });
-        if (existsSync(customEnvDb)) rmSync(customEnvDb);
+
+        try {
+            process.env.PKD_PATTERN_DIR = customDir;
+            
+            const customEngine = new TruthEngine(customEnvDb);
+            await customEngine.init();
+            
+            const result = await (customEngine as any).normalizer.normalize(1, 'CustomMfr', 'SUCCESS', 'https://test.com');
+            expect(result.status).toBe('HEALTHY');
+            customEngine.close();
+        } finally {
+            // High-Rigor: Ensure environment is restored even if test fails
+            process.env.PKD_PATTERN_DIR = originalEnv;
+            rmSync(customDir, { recursive: true, force: true });
+            if (existsSync(customEnvDb)) rmSync(customEnvDb);
+        }
     });
 });
 

--- a/packages/truth-engine/src/normalizer.test.ts
+++ b/packages/truth-engine/src/normalizer.test.ts
@@ -10,13 +10,14 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ForensicNormalizer } from './normalizer.js';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs';
 
 describe('ForensicNormalizer', () => {
-    // The test is running from packages/truth-engine
-    // Patterns are in packages/truth-engine/patterns
-    const patternDir = join(process.cwd(), 'patterns');
+    // High-Rigor: Use relative path from test file to find patterns, avoiding process.cwd() drift
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const patternDir = join(__dirname, '..', 'patterns');
     let normalizer: ForensicNormalizer;
 
     beforeEach(() => {
@@ -54,7 +55,7 @@ describe('ForensicNormalizer', () => {
 
     it('test_should_abort_via_temporal_warden_when_redos_pattern_encountered', async () => {
         // Create a malicious dialect in a temporary location
-        const redosDir = join(process.cwd(), '.artifacts', 'test_redos');
+        const redosDir = join(__dirname, '..', '.artifacts', 'test_redos');
         if (!existsSync(redosDir)) mkdirSync(redosDir, { recursive: true });
         
         const maliciousDialect = {

--- a/packages/truth-engine/src/normalizer.test.ts
+++ b/packages/truth-engine/src/normalizer.test.ts
@@ -5,7 +5,7 @@
  * Author: Richard D. (https://github.com/iamrichardd)
  * License: FSL-1.1 (See LICENSE file for details)
  * Purpose: Atomic verification of the ForensicNormalizer and Regex Warden.
- * Traceability: Issue #48, ADR-0017
+ * Traceability: Issue #48, ADR-0017, Issue #74
  * ======================================================================== */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -24,6 +24,10 @@ describe('ForensicNormalizer', () => {
         normalizer = new ForensicNormalizer(patternDir);
     });
 
+    /**
+     * Why: Verifies that the normalizer can correctly extract fields from a standard
+     * manufacturer string using weighted pattern matching.
+     */
     it('test_should_extract_metadata_when_pattern_matches_standard_dialect', async () => {
         const input = "208V 3PH 60HZ";
         const result = await normalizer.normalize(1, 'Frymaster', input, 'https://test.com');
@@ -36,6 +40,10 @@ describe('ForensicNormalizer', () => {
         });
     });
 
+    /**
+     * Why: Confirms that lower-weight "verbose" patterns are still correctly identified
+     * when standard patterns fail to match.
+     */
     it('test_should_extract_metadata_when_pattern_matches_verbose_dialect', async () => {
         const input = "240 Volts 1 Phase";
         const result = await normalizer.normalize(1, 'Frymaster', input, 'https://test.com');
@@ -45,6 +53,10 @@ describe('ForensicNormalizer', () => {
         expect(result.data?.phase).toBe("1");
     });
 
+    /**
+     * Why: Ensures the system fails gracefully (returning UNVERIFIED_RAW_DATA)
+     * when no known dialect patterns match the input string.
+     */
     it('test_should_return_unverified_raw_data_when_no_pattern_matches', async () => {
         const input = "UNKNOWN_POWER_FORMAT_999";
         const result = await normalizer.normalize(1, 'Frymaster', input, 'https://test.com');
@@ -53,6 +65,10 @@ describe('ForensicNormalizer', () => {
         expect(result.rejection_reason).toBe('No pattern match');
     });
 
+    /**
+     * Why: Critical security check for ReDoS immunity. Verifies that the Regex Warden
+     * kills worker threads that exceed the 100ms temporal sentinel.
+     */
     it('test_should_abort_via_temporal_warden_when_redos_pattern_encountered', async () => {
         // Create a malicious dialect in a temporary location
         const redosDir = join(__dirname, '..', '.artifacts', 'test_redos');


### PR DESCRIPTION
## ⚔️ The Pharos Crucible (Audit Log)

### 1. Issue Authority
- Closes #74.
- Branch: `fix/issue-74-ci-test-paths`

### 2. Strategy (Surgical Strike)
- Identified `process.cwd()` as the root cause of CI failures in `truth-engine` tests.
- Transitioned to `import.meta.url` based path resolution to ensure tests find artifacts (patterns, DBs) regardless of the execution context (root vs package).

### 3. Security Review
- No sensitive data exposed.
- Maintained Regex Warden temporal isolation.

### 4. DORA Metrics
- Lead Time: ~30m
- Change Failure Rate: 0% (verified in Podman container)

### 5. Verification
- 22 Atomic Tests passed in official project container (`Containerfile.truth-engine`).
- Verified robustness against `process.cwd()` drift.