### PR TITLE
fix(install): remove unnecessary curl dependency (#162)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -22,7 +22,7 @@
   File: scripts/install.ps1
   Author: Richard D. (https://github.com/iamrichardd)
   License: FSL-1.1 (See LICENSE file for details)
-  Traceability: Issue #94, ADR-0006, ADR-0017
+  Traceability: Issue #94, Issue #162, ADR-0006, ADR-0017
 #>
 
 # ========================================================================
@@ -33,7 +33,7 @@
 # Author: Richard D. (https://github.com/iamrichardd)
 # License: FSL-1.1 (See LICENSE file for details)
 # Purpose: Windows-native installer with high-rigor integrity checks.
-# Traceability: Issue #94
+# Traceability: Issue #94, Issue #162
 # ========================================================================
 
 param(
@@ -252,20 +252,6 @@ function Audit-Environment {
             exit 1
         }
         Log-Warn "Bypassing writability check due to -Force flag."
-    }
-
-    $missing = @()
-
-    if (-not (Get-Command "curl" -ErrorAction SilentlyContinue)) {
-        $missing += "curl"
-    }
-
-    if ($missing.Count -gt 0) {
-        Log-Error "Missing dependencies: $($missing -join ', ')"
-        if (-not $Force) {
-            exit 1
-        }
-        Log-Warn "Bypassing audit due to -Force flag."
     }
 
     Log-Info "Environment audit passed."


### PR DESCRIPTION
## 🚀 Summary
This PR remediates Issue #162 by removing the vestigial `curl` dependency from the Windows installation script (`scripts/install.ps1`).

### 🛠️ Key Changes
- **Surgical Strike**: Excised the `curl` check and `$missing` dependency logic from `Audit-Environment`.
- **Native Acquisition**: Confirmed that the script already utilizes native PowerShell and .NET primitives for artifact retrieval.
- **Traceability**: Updated the Standardized File Prologue.

### 🛡️ The Pharos Crucible (Audit Log)
- **Strategy**: Option A (Surgical Strike) implemented.
- **Verification**: Syntax integrity verified via sharded `pulse.sh` slices.
- **Verdict**: 🟢 PHAROS GREEN

Closes #162