### PR TITLE
feat: full RFC-2378 query logic integration (#138)

### DIFF
--- a/packages/pharos-protocol/src/lib.rs
+++ b/packages/pharos-protocol/src/lib.rs
@@ -20,4 +20,4 @@ pub use ast::Command;
 pub use lexer::tokenize;
 pub use metadata::{ParameterValue, PharosMetadataBuffer};
 pub use parser::{parse_command, ProtocolError};
-pub use wildcard::wildcard_match;
+pub use wildcard::{ph_match, wildcard_match};

--- a/packages/pharos-protocol/src/wildcard.rs
+++ b/packages/pharos-protocol/src/wildcard.rs
@@ -87,8 +87,14 @@ pub fn wildcard_match(text: &str, pattern: &str) -> Result<bool, WardenError> {
 /// Ph delimiters: space, tab, newline, comma, semicolon, and colon.
 pub fn ph_match(text: &str, pattern: &str) -> Result<bool, WardenError> {
     let delimiters = [' ', '\t', '\n', '\r', ',', ';', ':'];
-    let text_words: Vec<&str> = text.split(|c| delimiters.contains(&c)).filter(|s| !s.is_empty()).collect();
-    let pattern_words: Vec<&str> = pattern.split(|c| delimiters.contains(&c)).filter(|s| !s.is_empty()).collect();
+    let text_words: Vec<&str> = text
+        .split(|c| delimiters.contains(&c))
+        .filter(|s| !s.is_empty())
+        .collect();
+    let pattern_words: Vec<&str> = pattern
+        .split(|c| delimiters.contains(&c))
+        .filter(|s| !s.is_empty())
+        .collect();
 
     if pattern_words.is_empty() {
         return Ok(true);

--- a/packages/pharos-protocol/src/wildcard.rs
+++ b/packages/pharos-protocol/src/wildcard.rs
@@ -81,6 +81,36 @@ pub fn wildcard_match(text: &str, pattern: &str) -> Result<bool, WardenError> {
     match_internal(&text_chars, &pattern_chars, &mut warden)
 }
 
+/// Matches a string against a pattern using RFC 2378 word-by-word matching.
+///
+/// Both the text and the pattern are broken into words using the standard
+/// Ph delimiters: space, tab, newline, comma, semicolon, and colon.
+pub fn ph_match(text: &str, pattern: &str) -> Result<bool, WardenError> {
+    let delimiters = [' ', '\t', '\n', '\r', ',', ';', ':'];
+    let text_words: Vec<&str> = text.split(|c| delimiters.contains(&c)).filter(|s| !s.is_empty()).collect();
+    let pattern_words: Vec<&str> = pattern.split(|c| delimiters.contains(&c)).filter(|s| !s.is_empty()).collect();
+
+    if pattern_words.is_empty() {
+        return Ok(true);
+    }
+
+    // Every word in the pattern must match at least one word in the text.
+    for p_word in pattern_words {
+        let mut matched = false;
+        for t_word in &text_words {
+            if wildcard_match(t_word, p_word)? {
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
 fn match_internal(
     text: &[char],
     pattern: &[char],
@@ -174,6 +204,15 @@ mod tests {
         assert!(wildcard_match("tank", "t[ao]nk").unwrap());
         assert!(wildcard_match("tonk", "t[ao]nk").unwrap());
         assert!(!wildcard_match("tenk", "t[ao]nk").unwrap());
+    }
+
+    #[test]
+    fn test_should_match_word_by_word_ph_style() {
+        assert!(ph_match("Hobart Vulcan", "Hobart").unwrap());
+        assert!(ph_match("Hobart Vulcan", "Vulcan").unwrap());
+        assert!(ph_match("Hobart Vulcan", "Ho*").unwrap());
+        assert!(ph_match("Hobart Vulcan", "Hobart Vulcan").unwrap());
+        assert!(!ph_match("Hobart Vulcan", "Hobart dishwasher").unwrap());
     }
 
     #[test]

--- a/packages/pkd-core/src/bindings.rs
+++ b/packages/pkd-core/src/bindings.rs
@@ -12,13 +12,13 @@ use crate::lazy_loader::{LazyShardLoader, ShardFetcher};
 use crate::models::metadata::PharosMetadata;
 #[cfg(any(test, not(target_arch = "wasm32")))]
 use crate::models::metadata::RegistryShard;
+use crate::models::query::{filter_metadata, results_to_toon_json, QueryEvaluator};
 use crate::models::schema::PharosSchema;
 use crate::models::types::ParameterValue;
 use crate::validator::{LodValidator, SchemaValidator, ValidationError};
 use dashmap::DashMap;
-use serde::{Deserialize, Serialize};
-use crate::models::query::{filter_metadata, results_to_toon_json, QueryEvaluator};
 use pharos_protocol::Command;
+use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::future::Future;

--- a/packages/pkd-core/src/bindings.rs
+++ b/packages/pkd-core/src/bindings.rs
@@ -17,6 +17,8 @@ use crate::models::types::ParameterValue;
 use crate::validator::{LodValidator, SchemaValidator, ValidationError};
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
+use crate::models::query::{filter_metadata, results_to_toon_json, QueryEvaluator};
+use pharos_protocol::Command;
 use serde_wasm_bindgen;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::future::Future;
@@ -126,6 +128,38 @@ impl PharosRegistryHandle {
             .filter(|entry| entry.key().contains(&pattern))
             .map(|entry| entry.key().clone())
             .collect()
+    }
+
+    /// Executes an RFC 2378 query against the registry.
+    /// Why: Centralizes the search logic in the WASM core for cross-platform parity.
+    pub fn query_wasm(&self, query_string: String) -> Result<JsValue, JsValue> {
+        match self.query_internal(query_string) {
+            Ok(json) => Ok(serde_wasm_bindgen::to_value(&json).unwrap()),
+            Err(e) => Err(JsValue::from_str(&e)),
+        }
+    }
+}
+
+impl PharosRegistryHandle {
+    pub fn query_internal(&self, query_string: String) -> Result<serde_json::Value, String> {
+        let cmd = pharos_protocol::parse_command(&query_string).map_err(|e| e.to_string())?;
+
+        if let Command::Query {
+            selections,
+            returns,
+        } = cmd
+        {
+            let results: Vec<serde_json::Value> = self
+                .cache
+                .iter()
+                .filter(|entry| selections.matches(entry.value()))
+                .map(|entry| filter_metadata(entry.value(), &returns))
+                .collect();
+
+            Ok(results_to_toon_json(results, &returns))
+        } else {
+            Err("Only 'query' commands are supported".to_string())
+        }
     }
 
     #[cfg(any(test, not(target_arch = "wasm32")))]

--- a/packages/pkd-core/src/models/mod.rs
+++ b/packages/pkd-core/src/models/mod.rs
@@ -9,5 +9,6 @@
  * ======================================================================== */
 
 pub mod metadata;
+pub mod query;
 pub mod schema;
 pub mod types;

--- a/packages/pkd-core/src/models/query.rs
+++ b/packages/pkd-core/src/models/query.rs
@@ -1,0 +1,143 @@
+/* ========================================================================
+ * Project: Pharos Kitchen Design (Project Prism)
+ * Component: Core / Models
+ * File: packages/pkd-core/src/models/query.rs
+ * Author: Richard D. (https://github.com/iamrichardd)
+ * License: FSL-1.1 (See LICENSE file for details)
+ * Purpose: Evaluator for RFC 2378 selection filters.
+ * Traceability: Issue #138, RFC 2378 Section 2.3
+ * ======================================================================== */
+
+use crate::models::metadata::PharosMetadata;
+use crate::models::types::ParameterValue;
+use pharos_protocol::ast::SelectionFilter;
+use pharos_protocol::ph_match;
+
+pub trait QueryEvaluator {
+    fn matches(&self, metadata: &PharosMetadata) -> bool;
+}
+
+impl QueryEvaluator for SelectionFilter {
+    fn matches(&self, metadata: &PharosMetadata) -> bool {
+        match self {
+            SelectionFilter::Single(field_opt, pattern) => {
+                if let Some(field) = field_opt {
+                    // Match against a specific field
+                    let value = match field.as_str() {
+                        "name" => Some(metadata.name.clone()),
+                        "id" | "metadata_id" => Some(metadata.metadata_id.clone()),
+                        "manufacturer" => metadata.parameters.get("PKD_Manufacturer").map(|v| v.to_string()),
+                        "model" => metadata.parameters.get("PKD_ModelNumber").map(|v| v.to_string()),
+                        "category" => Some(metadata.classification.category.clone()),
+                        _ => metadata.parameters.get(field).map(|v| v.to_string()),
+                    };
+
+                    if let Some(val) = value {
+                        ph_match(&val.to_lowercase(), &pattern.to_lowercase()).unwrap_or(false)
+                    } else {
+                        false
+                    }
+                } else {
+                    // Attribute-less search: match against common fields
+                    // RFC 2378 doesn't strictly define this, but Pharos defaults to name/mfr/model
+                    let fields_to_check = vec![
+                        metadata.name.clone(),
+                        metadata.metadata_id.clone(),
+                        metadata.parameters.get("PKD_Manufacturer").map(|v| v.to_string()).unwrap_or_default(),
+                        metadata.parameters.get("PKD_ModelNumber").map(|v| v.to_string()).unwrap_or_default(),
+                    ];
+
+                    fields_to_check.iter().any(|val| {
+                        ph_match(&val.to_lowercase(), &pattern.to_lowercase()).unwrap_or(false)
+                    })
+                }
+            }
+            SelectionFilter::And(filters) => {
+                filters.iter().all(|f| f.matches(metadata))
+            }
+            SelectionFilter::Or(filters) => {
+                filters.iter().any(|f| f.matches(metadata))
+            }
+        }
+    }
+}
+
+/// Filters a PharosMetadata object into a simplified map based on a 'return' clause.
+/// Why: Reduces data egress for UI-only previews and enforces schema-based selection.
+pub fn filter_metadata(metadata: &PharosMetadata, returns: &[String]) -> serde_json::Value {
+    let effective_returns = if returns.is_empty() {
+        vec!["metadata_id".to_string(), "name".to_string(), "manufacturer".to_string(), "model".to_string(), "category".to_string()]
+    } else {
+        returns.to_vec()
+    };
+
+    let mut result = serde_json::Map::new();
+    for field in effective_returns {
+        let value = match field.as_str() {
+            "name" => Some(serde_json::Value::String(metadata.name.clone())),
+            "id" | "metadata_id" => Some(serde_json::Value::String(metadata.metadata_id.clone())),
+            "category" => Some(serde_json::Value::String(metadata.classification.category.clone())),
+            "manufacturer" => metadata.parameters.get("PKD_Manufacturer").map(|v| {
+                match v {
+                    ParameterValue::Text(s) => serde_json::Value::String(s.clone()),
+                    _ => serde_json::to_value(v).unwrap(),
+                }
+            }),
+            "model" => metadata.parameters.get("PKD_ModelNumber").map(|v| {
+                match v {
+                    ParameterValue::Text(s) => serde_json::Value::String(s.clone()),
+                    _ => serde_json::to_value(v).unwrap(),
+                }
+            }),
+            _ => metadata.parameters.get(&field).map(|v| serde_json::to_value(v).unwrap()),
+        };
+
+        if let Some(val) = value {
+            result.insert(field, val);
+        }
+    }
+
+    serde_json::Value::Object(result)
+}
+
+/// Formats search results as a ToonDoc-compatible JSON structure.
+/// Why: Enables seamless integration with the TOON parser and UI loader.
+pub fn results_to_toon_json(results: Vec<serde_json::Value>, returns: &[String]) -> serde_json::Value {
+    let mut lists = serde_json::Map::new();
+
+    let schema = if returns.is_empty() {
+        // Default schema if none provided
+        vec!["metadata_id".to_string(), "name".to_string(), "manufacturer".to_string(), "model".to_string(), "category".to_string()]
+    } else {
+        returns.to_vec()
+    };
+
+    let mut items = Vec::new();
+    for res in results {
+        let mut row = Vec::new();
+        if let serde_json::Value::Object(map) = res {
+            for field in &schema {
+                let val = map.get(field).cloned().unwrap_or(serde_json::Value::String("".to_string()));
+                // TOON expects raw strings in its items lists
+                let val_str = match val {
+                    serde_json::Value::String(s) => s,
+                    _ => val.to_string(),
+                };
+                row.push(val_str);
+            }
+        }
+        items.push(row);
+    }
+
+    let mut results_list = serde_json::Map::new();
+    results_list.insert("schema".to_string(), serde_json::to_value(&schema).unwrap());
+    results_list.insert("items".to_string(), serde_json::to_value(&items).unwrap());
+
+    lists.insert("results".to_string(), serde_json::Value::Object(results_list));
+
+    let mut doc = serde_json::Map::new();
+    doc.insert("metadata".to_string(), serde_json::Value::Object(serde_json::Map::new()));
+    doc.insert("lists".to_string(), serde_json::Value::Object(lists));
+
+    serde_json::Value::Object(doc)
+}

--- a/packages/pkd-core/src/models/query.rs
+++ b/packages/pkd-core/src/models/query.rs
@@ -26,8 +26,14 @@ impl QueryEvaluator for SelectionFilter {
                     let value = match field.as_str() {
                         "name" => Some(metadata.name.clone()),
                         "id" | "metadata_id" => Some(metadata.metadata_id.clone()),
-                        "manufacturer" => metadata.parameters.get("PKD_Manufacturer").map(|v| v.to_string()),
-                        "model" => metadata.parameters.get("PKD_ModelNumber").map(|v| v.to_string()),
+                        "manufacturer" => metadata
+                            .parameters
+                            .get("PKD_Manufacturer")
+                            .map(|v| v.to_string()),
+                        "model" => metadata
+                            .parameters
+                            .get("PKD_ModelNumber")
+                            .map(|v| v.to_string()),
                         "category" => Some(metadata.classification.category.clone()),
                         _ => metadata.parameters.get(field).map(|v| v.to_string()),
                     };
@@ -40,11 +46,19 @@ impl QueryEvaluator for SelectionFilter {
                 } else {
                     // Attribute-less search: match against common fields
                     // RFC 2378 doesn't strictly define this, but Pharos defaults to name/mfr/model
-                    let fields_to_check = vec![
+                    let fields_to_check = [
                         metadata.name.clone(),
                         metadata.metadata_id.clone(),
-                        metadata.parameters.get("PKD_Manufacturer").map(|v| v.to_string()).unwrap_or_default(),
-                        metadata.parameters.get("PKD_ModelNumber").map(|v| v.to_string()).unwrap_or_default(),
+                        metadata
+                            .parameters
+                            .get("PKD_Manufacturer")
+                            .map(|v| v.to_string())
+                            .unwrap_or_default(),
+                        metadata
+                            .parameters
+                            .get("PKD_ModelNumber")
+                            .map(|v| v.to_string())
+                            .unwrap_or_default(),
                     ];
 
                     fields_to_check.iter().any(|val| {
@@ -52,12 +66,8 @@ impl QueryEvaluator for SelectionFilter {
                     })
                 }
             }
-            SelectionFilter::And(filters) => {
-                filters.iter().all(|f| f.matches(metadata))
-            }
-            SelectionFilter::Or(filters) => {
-                filters.iter().any(|f| f.matches(metadata))
-            }
+            SelectionFilter::And(filters) => filters.iter().all(|f| f.matches(metadata)),
+            SelectionFilter::Or(filters) => filters.iter().any(|f| f.matches(metadata)),
         }
     }
 }
@@ -66,7 +76,13 @@ impl QueryEvaluator for SelectionFilter {
 /// Why: Reduces data egress for UI-only previews and enforces schema-based selection.
 pub fn filter_metadata(metadata: &PharosMetadata, returns: &[String]) -> serde_json::Value {
     let effective_returns = if returns.is_empty() {
-        vec!["metadata_id".to_string(), "name".to_string(), "manufacturer".to_string(), "model".to_string(), "category".to_string()]
+        vec![
+            "metadata_id".to_string(),
+            "name".to_string(),
+            "manufacturer".to_string(),
+            "model".to_string(),
+            "category".to_string(),
+        ]
     } else {
         returns.to_vec()
     };
@@ -76,20 +92,24 @@ pub fn filter_metadata(metadata: &PharosMetadata, returns: &[String]) -> serde_j
         let value = match field.as_str() {
             "name" => Some(serde_json::Value::String(metadata.name.clone())),
             "id" | "metadata_id" => Some(serde_json::Value::String(metadata.metadata_id.clone())),
-            "category" => Some(serde_json::Value::String(metadata.classification.category.clone())),
-            "manufacturer" => metadata.parameters.get("PKD_Manufacturer").map(|v| {
-                match v {
+            "category" => Some(serde_json::Value::String(
+                metadata.classification.category.clone(),
+            )),
+            "manufacturer" => metadata
+                .parameters
+                .get("PKD_Manufacturer")
+                .map(|v| match v {
                     ParameterValue::Text(s) => serde_json::Value::String(s.clone()),
                     _ => serde_json::to_value(v).unwrap(),
-                }
+                }),
+            "model" => metadata.parameters.get("PKD_ModelNumber").map(|v| match v {
+                ParameterValue::Text(s) => serde_json::Value::String(s.clone()),
+                _ => serde_json::to_value(v).unwrap(),
             }),
-            "model" => metadata.parameters.get("PKD_ModelNumber").map(|v| {
-                match v {
-                    ParameterValue::Text(s) => serde_json::Value::String(s.clone()),
-                    _ => serde_json::to_value(v).unwrap(),
-                }
-            }),
-            _ => metadata.parameters.get(&field).map(|v| serde_json::to_value(v).unwrap()),
+            _ => metadata
+                .parameters
+                .get(&field)
+                .map(|v| serde_json::to_value(v).unwrap()),
         };
 
         if let Some(val) = value {
@@ -102,12 +122,21 @@ pub fn filter_metadata(metadata: &PharosMetadata, returns: &[String]) -> serde_j
 
 /// Formats search results as a ToonDoc-compatible JSON structure.
 /// Why: Enables seamless integration with the TOON parser and UI loader.
-pub fn results_to_toon_json(results: Vec<serde_json::Value>, returns: &[String]) -> serde_json::Value {
+pub fn results_to_toon_json(
+    results: Vec<serde_json::Value>,
+    returns: &[String],
+) -> serde_json::Value {
     let mut lists = serde_json::Map::new();
 
     let schema = if returns.is_empty() {
         // Default schema if none provided
-        vec!["metadata_id".to_string(), "name".to_string(), "manufacturer".to_string(), "model".to_string(), "category".to_string()]
+        vec![
+            "metadata_id".to_string(),
+            "name".to_string(),
+            "manufacturer".to_string(),
+            "model".to_string(),
+            "category".to_string(),
+        ]
     } else {
         returns.to_vec()
     };
@@ -117,7 +146,10 @@ pub fn results_to_toon_json(results: Vec<serde_json::Value>, returns: &[String])
         let mut row = Vec::new();
         if let serde_json::Value::Object(map) = res {
             for field in &schema {
-                let val = map.get(field).cloned().unwrap_or(serde_json::Value::String("".to_string()));
+                let val = map
+                    .get(field)
+                    .cloned()
+                    .unwrap_or(serde_json::Value::String("".to_string()));
                 // TOON expects raw strings in its items lists
                 let val_str = match val {
                     serde_json::Value::String(s) => s,
@@ -133,10 +165,16 @@ pub fn results_to_toon_json(results: Vec<serde_json::Value>, returns: &[String])
     results_list.insert("schema".to_string(), serde_json::to_value(&schema).unwrap());
     results_list.insert("items".to_string(), serde_json::to_value(&items).unwrap());
 
-    lists.insert("results".to_string(), serde_json::Value::Object(results_list));
+    lists.insert(
+        "results".to_string(),
+        serde_json::Value::Object(results_list),
+    );
 
     let mut doc = serde_json::Map::new();
-    doc.insert("metadata".to_string(), serde_json::Value::Object(serde_json::Map::new()));
+    doc.insert(
+        "metadata".to_string(),
+        serde_json::Value::Object(serde_json::Map::new()),
+    );
     doc.insert("lists".to_string(), serde_json::Value::Object(lists));
 
     serde_json::Value::Object(doc)

--- a/packages/pkd-core/src/tests/mod.rs
+++ b/packages/pkd-core/src/tests/mod.rs
@@ -9,6 +9,7 @@
  * ======================================================================== */
 
 pub mod deserialization;
+pub mod query_integration;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod jit_actor;

--- a/packages/pkd-core/src/tests/query_integration.rs
+++ b/packages/pkd-core/src/tests/query_integration.rs
@@ -10,14 +10,20 @@
 
 use crate::bindings::PharosRegistryHandle;
 use crate::models::metadata::{Classification, PerformanceMetadata, PharosMetadata};
-use std::collections::BTreeMap;
 use pharos_protocol::metadata::ParameterValue;
+use std::collections::BTreeMap;
 
 fn create_mock_metadata(id: &str, name: &str, mfr: &str, model: &str) -> PharosMetadata {
     let mut parameters = BTreeMap::new();
-    parameters.insert("PKD_Manufacturer".to_string(), ParameterValue::Text(mfr.to_string()));
-    parameters.insert("PKD_ModelNumber".to_string(), ParameterValue::Text(model.to_string()));
-    
+    parameters.insert(
+        "PKD_Manufacturer".to_string(),
+        ParameterValue::Text(mfr.to_string()),
+    );
+    parameters.insert(
+        "PKD_ModelNumber".to_string(),
+        ParameterValue::Text(model.to_string()),
+    );
+
     PharosMetadata {
         metadata_id: id.to_string(),
         name: name.to_string(),
@@ -40,17 +46,27 @@ fn create_mock_metadata(id: &str, name: &str, mfr: &str, model: &str) -> PharosM
 #[test]
 fn test_should_match_query_by_manufacturer_when_using_wildcards() {
     let handle = PharosRegistryHandle::new();
-    handle.cache.insert("1".to_string(), create_mock_metadata("1", "Dishwasher", "Hobart", "PHX-1"));
-    handle.cache.insert("2".to_string(), create_mock_metadata("2", "Oven", "Vulcan", "V-100"));
-    
+    handle.cache.insert(
+        "1".to_string(),
+        create_mock_metadata("1", "Dishwasher", "Hobart", "PHX-1"),
+    );
+    handle.cache.insert(
+        "2".to_string(),
+        create_mock_metadata("2", "Oven", "Vulcan", "V-100"),
+    );
+
     // Test exact match
-    let res = handle.query_internal("query manufacturer=Hobart".to_string()).unwrap();
+    let res = handle
+        .query_internal("query manufacturer=Hobart".to_string())
+        .unwrap();
     let results = res["lists"]["results"]["items"].as_array().unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0][2], "Hobart");
 
     // Test wildcard match
-    let res = handle.query_internal("query manufacturer=V*".to_string()).unwrap();
+    let res = handle
+        .query_internal("query manufacturer=V*".to_string())
+        .unwrap();
     let results = res["lists"]["results"]["items"].as_array().unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0][2], "Vulcan");
@@ -63,7 +79,7 @@ fn test_query_logic_directly() {
     use pharos_protocol::Command;
 
     let m1 = create_mock_metadata("1", "Dishwasher", "Hobart Vulcan", "PHX-1");
-    
+
     // RFC 2378 Section 2.2 style examples
     let cmd = parse_command("query manufacturer=Hobart").unwrap();
     if let Command::Query { selections, .. } = cmd {
@@ -84,7 +100,7 @@ fn test_query_logic_directly() {
     if let Command::Query { selections, .. } = cmd {
         assert!(selections.matches(&m1));
     }
-    
+
     // Multiple words in query
     let cmd = parse_command("query manufacturer=\"Hobart Vulcan\"").unwrap();
     if let Command::Query { selections, .. } = cmd {

--- a/packages/pkd-core/src/tests/query_integration.rs
+++ b/packages/pkd-core/src/tests/query_integration.rs
@@ -1,0 +1,93 @@
+/* ========================================================================
+ * Project: Pharos Kitchen Design (Project Prism)
+ * Component: Core / Tests
+ * File: packages/pkd-core/src/tests/query_integration.rs
+ * Author: Richard D. (https://github.com/iamrichardd)
+ * License: FSL-1.1 (See LICENSE file for details)
+ * Purpose: Integration tests for RFC 2378 query logic.
+ * Traceability: Issue #138, Task 4.32.3
+ * ======================================================================== */
+
+use crate::bindings::PharosRegistryHandle;
+use crate::models::metadata::{Classification, PerformanceMetadata, PharosMetadata};
+use std::collections::BTreeMap;
+use pharos_protocol::metadata::ParameterValue;
+
+fn create_mock_metadata(id: &str, name: &str, mfr: &str, model: &str) -> PharosMetadata {
+    let mut parameters = BTreeMap::new();
+    parameters.insert("PKD_Manufacturer".to_string(), ParameterValue::Text(mfr.to_string()));
+    parameters.insert("PKD_ModelNumber".to_string(), ParameterValue::Text(model.to_string()));
+    
+    PharosMetadata {
+        metadata_id: id.to_string(),
+        name: name.to_string(),
+        schema_version: "1.0.0".to_string(),
+        classification: Classification {
+            omniclass_table_23: "23-00".to_string(),
+            category: "Test".to_string(),
+        },
+        parameters,
+        lod_geometry_specs: BTreeMap::new(),
+        geometry_manifest: None,
+        performance_metadata: PerformanceMetadata {
+            estimated_rfa_size_kb: 10,
+            procedural_lod_enabled: true,
+            ghost_link_active: true,
+        },
+    }
+}
+
+#[test]
+fn test_should_match_query_by_manufacturer_when_using_wildcards() {
+    let handle = PharosRegistryHandle::new();
+    handle.cache.insert("1".to_string(), create_mock_metadata("1", "Dishwasher", "Hobart", "PHX-1"));
+    handle.cache.insert("2".to_string(), create_mock_metadata("2", "Oven", "Vulcan", "V-100"));
+    
+    // Test exact match
+    let res = handle.query_internal("query manufacturer=Hobart".to_string()).unwrap();
+    let results = res["lists"]["results"]["items"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0][2], "Hobart");
+
+    // Test wildcard match
+    let res = handle.query_internal("query manufacturer=V*".to_string()).unwrap();
+    let results = res["lists"]["results"]["items"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0][2], "Vulcan");
+}
+
+#[test]
+fn test_query_logic_directly() {
+    use crate::models::query::QueryEvaluator;
+    use pharos_protocol::parse_command;
+    use pharos_protocol::Command;
+
+    let m1 = create_mock_metadata("1", "Dishwasher", "Hobart Vulcan", "PHX-1");
+    
+    // RFC 2378 Section 2.2 style examples
+    let cmd = parse_command("query manufacturer=Hobart").unwrap();
+    if let Command::Query { selections, .. } = cmd {
+        assert!(selections.matches(&m1));
+    }
+
+    let cmd = parse_command("query manufacturer=Vulcan").unwrap();
+    if let Command::Query { selections, .. } = cmd {
+        assert!(selections.matches(&m1));
+    }
+
+    let cmd = parse_command("query manufacturer=Ho*").unwrap();
+    if let Command::Query { selections, .. } = cmd {
+        assert!(selections.matches(&m1));
+    }
+
+    let cmd = parse_command("query manufacturer=Vul*").unwrap();
+    if let Command::Query { selections, .. } = cmd {
+        assert!(selections.matches(&m1));
+    }
+    
+    // Multiple words in query
+    let cmd = parse_command("query manufacturer=\"Hobart Vulcan\"").unwrap();
+    if let Command::Query { selections, .. } = cmd {
+        assert!(selections.matches(&m1));
+    }
+}

--- a/packages/pkd-toon/src/lib.rs
+++ b/packages/pkd-toon/src/lib.rs
@@ -243,7 +243,10 @@ tasks[2]{id, title, status}:
 
     #[test]
     fn test_should_parse_manifesto_from_filesystem() {
-        let content = std::fs::read_to_string("../../apps/marketing/src/content/updates/2026-05-28-project-genesis.toon").unwrap();
+        let content = std::fs::read_to_string(
+            "../../apps/marketing/src/content/updates/2026-05-28-project-genesis.toon",
+        )
+        .unwrap();
         let result = ToonParser::parse(&content);
         assert!(result.is_ok(), "Manifesto Parse Error: {:?}", result.err());
     }


### PR DESCRIPTION
## Strategic Alignment
This PR implements the full query and wildcard semantics defined in RFC-2378 (Ph Nameserver Protocol), as mandated by Issue #138. This is a critical step for AEC metadata interoperability and eliminates the "Hallucination Gap" in equipment discovery.

## Technical Summary
- **pharos-protocol**: Added `ph_match` for word-by-word matching and extended wildcards (`+`, `?`, `[]`).
- **pkd-core**: Implemented `QueryEvaluator` and `filter_metadata` to handle selection and projection.
- **WASM Interop**: Updated `query_wasm` to return results in a `ToonDoc` compatible structure for the UI.
- **Security**: All wildcard matching is protected by the Temporal Warden sentinel (100ms timeout).

## Verification Results
- 🟢 **PHAROS GREEN** in Podman.
- 33/33 tests passed in `pkd-core`.
- Atomic tests added for RFC-2378 Section 2.2 empirical compliance.