### PR TITLE
feat: PharosMetadata Builder Pattern (#148)

### DIFF
--- a/@PROGRESS.md
+++ b/@PROGRESS.md
@@ -29,6 +29,16 @@
 - [x] **Issue #168**: Implemented Automated Boundary Enforcement (ADR-0044) and drift detection.
 - **Verification**: 🟢 PHAROS GREEN confirmed across all monorepo slices.
 
+### Sprint 5.01: Core Parser & Remediation (2026-06-01) - 🚀 ACTIVE
+- [x] **Issue #141**: Implemented Relational Handle Mapping for the TOON Parser (Option C).
+    - Maintained O(n) linear parsing velocity by shifting resolution to consumers.
+    - Added TDD coverage for namespaced handles and metadata cross-references.
+    - Verified 🟢 PHAROS GREEN in Podman.
+- [ ] **Issue #138**: Task 4.32: Implement Full RFC-2378 Query Logic in WASM Core. [Strategy Phase]
+- [ ] **Issue #148**: Debt: Implement `PharosMetadata::builder()` pattern.
+- [ ] **Issue #187**: [DEBT] Investigate and Resolve CI Build Warnings.
+- [ ] **Issue #139**: Debt #139: Enhanced TOON Diagnostics (Blocked by #141).
+
 ---
 
 ## ✅ Completed Sprints

--- a/@PROGRESS.md
+++ b/@PROGRESS.md
@@ -30,18 +30,18 @@
 - **Verification**: 🟢 PHAROS GREEN confirmed across all monorepo slices.
 
 ### Sprint 5.01: Core Parser & Remediation (2026-06-01) - 🚀 ACTIVE
-- [x] **Issue #141**: Implemented Relational Handle Mapping for the TOON Parser (Option C).
+- [x] **Issue #141**: Implemented Relational Handle Mapping for the TOON Parser (Option C). [ECT: 3 | ACT: 2]
     - Maintained O(n) linear parsing velocity by shifting resolution to consumers.
     - Added TDD coverage for namespaced handles and metadata cross-references.
     - Verified 🟢 PHAROS GREEN in Podman.
-- [x] **Issue #138**: Implemented full RFC-2378 Query Logic and Wildcard Engine (Option B).
+- [x] **Issue #138**: Implemented full RFC-2378 Query Logic and Wildcard Engine (Option B). [ECT: 3 | ACT: 3]
     - Support for Ph-standard word-by-word matching and advanced wildcards (*, +, ?, []).
     - Implemented `return` clauses for field projection and reduced data egress.
     - Enforced **Temporal Warden** (100ms sentinel) for ReDoS immunity.
     - Verified 🟢 PHAROS GREEN with 33 integration tests in Podman.
-- [ ] **Issue #148**: Debt: Implement `PharosMetadata::builder()` pattern.
-- [ ] **Issue #187**: [DEBT] Investigate and Resolve CI Build Warnings.
-- [ ] **Issue #139**: Debt #139: Enhanced TOON Diagnostics (Blocked by #141).
+- [ ] **Issue #148**: Debt: Implement `PharosMetadata::builder()` pattern. [ECT: 2]
+- [ ] **Issue #187**: [DEBT] Investigate and Resolve CI Build Warnings. [ECT: 2]
+- [ ] **Issue #139**: Debt #139: Enhanced TOON Diagnostics (Blocked by #141). [ECT: 2]
 
 ---
 

--- a/@PROGRESS.md
+++ b/@PROGRESS.md
@@ -34,7 +34,11 @@
     - Maintained O(n) linear parsing velocity by shifting resolution to consumers.
     - Added TDD coverage for namespaced handles and metadata cross-references.
     - Verified 🟢 PHAROS GREEN in Podman.
-- [ ] **Issue #138**: Task 4.32: Implement Full RFC-2378 Query Logic in WASM Core. [Strategy Phase]
+- [x] **Issue #138**: Implemented full RFC-2378 Query Logic and Wildcard Engine (Option B).
+    - Support for Ph-standard word-by-word matching and advanced wildcards (*, +, ?, []).
+    - Implemented `return` clauses for field projection and reduced data egress.
+    - Enforced **Temporal Warden** (100ms sentinel) for ReDoS immunity.
+    - Verified 🟢 PHAROS GREEN with 33 integration tests in Podman.
 - [ ] **Issue #148**: Debt: Implement `PharosMetadata::builder()` pattern.
 - [ ] **Issue #187**: [DEBT] Investigate and Resolve CI Build Warnings.
 - [ ] **Issue #139**: Debt #139: Enhanced TOON Diagnostics (Blocked by #141).

--- a/@TODO.md
+++ b/@TODO.md
@@ -18,8 +18,8 @@
  -->
 
 ### Sprint 5.01: Core Parser & Remediation (2026-06-01) - 🚀 ACTIVE
-- [x] **Issue #141**: Task 4.33: Recursive Tabular Indentation for TOON Parser. (Implemented as Relational Handle Mapping)
-- [x] **Issue #138**: Task 4.32: Implement Full RFC-2378 Query Logic in WASM Core.
+- [x] **Issue #141**: Task 4.33: Recursive Tabular Indentation for TOON Parser. (Implemented as Relational Handle Mapping) [ECT: 3 | ACT: 2]
+- [x] **Issue #138**: Task 4.32: Implement Full RFC-2378 Query Logic in WASM Core. [ECT: 3 | ACT: 3]
 - [ ] **Issue #148**: Debt: Implement \`PharosMetadata::builder()\` pattern. [ECT: 2]
 - [ ] **Issue #187**: [DEBT] Investigate and Resolve CI Build Warnings. [ECT: 2]
 - [ ] **Issue #139**: Debt #139: Enhanced TOON Diagnostics (Blocked by #141). [ECT: 2]

--- a/@TODO.md
+++ b/@TODO.md
@@ -19,7 +19,7 @@
 
 ### Sprint 5.01: Core Parser & Remediation (2026-06-01) - 🚀 ACTIVE
 - [x] **Issue #141**: Task 4.33: Recursive Tabular Indentation for TOON Parser. (Implemented as Relational Handle Mapping)
-- [ ] **Issue #138**: Task 4.32: Implement Full RFC-2378 Query Logic in WASM Core. [ECT: 3]
+- [x] **Issue #138**: Task 4.32: Implement Full RFC-2378 Query Logic in WASM Core.
 - [ ] **Issue #148**: Debt: Implement \`PharosMetadata::builder()\` pattern. [ECT: 2]
 - [ ] **Issue #187**: [DEBT] Investigate and Resolve CI Build Warnings. [ECT: 2]
 - [ ] **Issue #139**: Debt #139: Enhanced TOON Diagnostics (Blocked by #141). [ECT: 2]

--- a/@TODO.md
+++ b/@TODO.md
@@ -17,8 +17,8 @@
  * 5. ATOMICITY: Focus on one Phase/Task at a time. Do not "scatter" progress across unrelated silos.
  -->
 
-### Sprint 5.01: Core Parser & Remediation (2026-06-01) - 🚀 PLANNED
-- [ ] **Issue #141**: Task 4.33: Recursive Tabular Indentation for TOON Parser. [ECT: 3]
+### Sprint 5.01: Core Parser & Remediation (2026-06-01) - 🚀 ACTIVE
+- [x] **Issue #141**: Task 4.33: Recursive Tabular Indentation for TOON Parser. (Implemented as Relational Handle Mapping)
 - [ ] **Issue #138**: Task 4.32: Implement Full RFC-2378 Query Logic in WASM Core. [ECT: 3]
 - [ ] **Issue #148**: Debt: Implement \`PharosMetadata::builder()\` pattern. [ECT: 2]
 - [ ] **Issue #187**: [DEBT] Investigate and Resolve CI Build Warnings. [ECT: 2]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -2471,7 +2471,7 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "web-time",
 ]
 
@@ -5069,6 +5069,12 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -5317,22 +5323,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.211.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7d931a1120ef357f32b74547646b6fa68ea25e377772b72874b131a9ed70d4"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.249.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69830ccbbf41c55eb585991659fb70867ef628193af3a495f09a6956f7615e59"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.249.0",
 ]
 
 [[package]]
@@ -5365,17 +5370,6 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.249.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30538cae9a794215f490b532df01c557e2e2bfac92569482554acd0992a102ea"
-dependencies = [
- "bitflags 2.11.1",
  "indexmap",
  "semver",
 ]
@@ -5665,22 +5659,22 @@ checksum = "67761d8f8c0b3c13a5d34356274b10a40baba67fe9cfabbfc379a8b414e45de2"
 
 [[package]]
 name = "wast"
-version = "249.0.0"
+version = "211.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474a321bf9ae2808e9fa23ac4ec2b27300e70985e30bcb5a38d43b76bfc901a"
+checksum = "b25506dd82d00da6b14a87436b3d52b1d264083fa79cdb72a0d1b04a8595ccaa"
 dependencies = [
  "bumpalo",
- "leb128fmt",
+ "leb128",
  "memchr",
- "unicode-width",
- "wasm-encoder 0.249.0",
+ "unicode-width 0.1.14",
+ "wasm-encoder 0.211.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.249.0"
+version = "1.211.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28af699d0a9c7e4e250b7b8e36167ae5215fbb4b7ae526bb4ce7b234ba0afc90"
+checksum = "779365ca4640d48cd714788626bb622b4f491d7cd3d3ecb1a48bad4082f420ac"
 dependencies = [
  "wast",
 ]

--- a/packages/pkd-core/Cargo.toml
+++ b/packages/pkd-core/Cargo.toml
@@ -35,4 +35,4 @@ dashmap = { version = "5.5", features = ["serde"] }
 
 [dev-dependencies]
 tempfile = "3.10"
-wat = "1.0"
+wat = "1.211.0"

--- a/packages/pkd-core/src/models/metadata.rs
+++ b/packages/pkd-core/src/models/metadata.rs
@@ -4,8 +4,8 @@
  * File: metadata.rs
  * Author: Richard D. (https://github.com/iamrichardd)
  * License: FSL-1.1 (See LICENSE file for details)
- * Purpose: Product metadata model for PKD assets.
- * Traceability: Issue #9, ADR 0002, Issue #124
+ * Purpose: Product metadata model for PKD assets. Builder Pattern implementation.
+ * Traceability: Issue #9, ADR 0002, Issue #124, Issue #148
  * ======================================================================== */
 
 pub use pharos_protocol::metadata::{
@@ -55,4 +55,136 @@ pub struct RegistryShard {
     pub shard_id: String,
     pub v: String,
     pub records: BTreeMap<String, PharosMetadata>,
+}
+
+impl PharosMetadata {
+    /// Rationale: Provides a fluent API for constructing complex metadata objects
+    /// while ensuring all mandatory fields are present.
+    pub fn builder() -> PharosMetadataBuilder {
+        PharosMetadataBuilder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct PharosMetadataBuilder {
+    metadata_id: Option<String>,
+    name: Option<String>,
+    schema_version: Option<String>,
+    classification: Option<Classification>,
+    parameters: BTreeMap<String, ParameterValue>,
+    lod_geometry_specs: BTreeMap<String, LodGeometrySpec>,
+    geometry_manifest: Option<GeometryManifest>,
+    performance_metadata: Option<PerformanceMetadata>,
+}
+
+impl PharosMetadataBuilder {
+    pub fn metadata_id(mut self, id: String) -> Self {
+        self.metadata_id = Some(id);
+        self
+    }
+
+    pub fn name(mut self, name: String) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn schema_version(mut self, version: String) -> Self {
+        self.schema_version = Some(version);
+        self
+    }
+
+    pub fn classification(mut self, classification: Classification) -> Self {
+        self.classification = Some(classification);
+        self
+    }
+
+    pub fn parameters(mut self, parameters: BTreeMap<String, ParameterValue>) -> Self {
+        self.parameters = parameters;
+        self
+    }
+
+    pub fn add_parameter(mut self, key: String, value: ParameterValue) -> Self {
+        self.parameters.insert(key, value);
+        self
+    }
+
+    pub fn lod_geometry_specs(mut self, specs: BTreeMap<String, LodGeometrySpec>) -> Self {
+        self.lod_geometry_specs = specs;
+        self
+    }
+
+    pub fn add_lod_spec(mut self, lod: String, spec: LodGeometrySpec) -> Self {
+        self.lod_geometry_specs.insert(lod, spec);
+        self
+    }
+
+    pub fn geometry_manifest(mut self, manifest: GeometryManifest) -> Self {
+        self.geometry_manifest = Some(manifest);
+        self
+    }
+
+    pub fn performance_metadata(mut self, performance: PerformanceMetadata) -> Self {
+        self.performance_metadata = Some(performance);
+        self
+    }
+
+    /// Rationale: Validates that all mandatory fields are set before instantiating PharosMetadata.
+    /// This prevents "failing slowly" by detecting missing configuration at the seam.
+    pub fn build(self) -> Result<PharosMetadata, String> {
+        let metadata_id = self.metadata_id.ok_or_else(|| "metadata_id is required".to_string())?;
+        let name = self.name.ok_or_else(|| "name is required".to_string())?;
+        let schema_version = self.schema_version.ok_or_else(|| "schema_version is required".to_string())?;
+        let classification = self.classification.ok_or_else(|| "classification is required".to_string())?;
+        let performance_metadata = self.performance_metadata.ok_or_else(|| "performance_metadata is required".to_string())?;
+
+        Ok(PharosMetadata {
+            metadata_id,
+            name,
+            schema_version,
+            classification,
+            parameters: self.parameters,
+            lod_geometry_specs: self.lod_geometry_specs,
+            geometry_manifest: self.geometry_manifest,
+            performance_metadata,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_instantiate_metadata_when_using_builder() {
+        let metadata = PharosMetadata::builder()
+            .metadata_id("test-id".to_string())
+            .name("Test Product".to_string())
+            .schema_version("1.0.0".to_string())
+            .classification(Classification {
+                omniclass_table_23: "23-75 70 11 11".to_string(),
+                category: "Fryers".to_string(),
+            })
+            .performance_metadata(PerformanceMetadata {
+                estimated_rfa_size_kb: 150,
+                procedural_lod_enabled: true,
+                ghost_link_active: false,
+            })
+            .build()
+            .expect("Builder should succeed with mandatory fields");
+
+        assert_eq!(metadata.metadata_id, "test-id");
+        assert_eq!(metadata.name, "Test Product");
+        assert_eq!(metadata.classification.category, "Fryers");
+        assert!(metadata.parameters.is_empty());
+    }
+
+    #[test]
+    fn test_should_fail_when_mandatory_field_missing() {
+        let result = PharosMetadata::builder()
+            .name("Test Product".to_string())
+            .build();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("metadata_id"));
+    }
 }


### PR DESCRIPTION
## Summary
Implemented a manual Builder Pattern for the `PharosMetadata` struct to improve ergonomics and enforce "Fail Fast" validation of mandatory fields.

## Strategic Alignment
- **VSA/Clean Architecture**: Simplifies metadata construction across vertical slices.
- **Fail-Fast**: Mandatory fields are validated at the system seam during `build()`.
- **TDD**: Added atomic tests verifying successful instantiation and failure on missing fields.

## Implementation Details
- Added `PharosMetadataBuilder` with fluent API.
- Added `PharosMetadata::builder()` entry point.
- Pinned `wat` version in `pkd-core` to resolve `edition2024` build failures on stable Rust.

## Verification (🟢 PHAROS GREEN)
Verified in Podman using `rust:latest`:
- `cargo test -p pkd-core --lib models::metadata::tests` -> PASSED

Closes #148