### PR TITLE
feat(marketing): pivot to registration on user_not_found

### DIFF
--- a/apps/marketing/src/pages/verify.astro
+++ b/apps/marketing/src/pages/verify.astro
@@ -124,42 +124,62 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
     try {
         // 1. Fetch Auth Options
-        const optionsRes = await fetch(`${AUTH_URL}/auth/login/options`, {
+        let isRegistration = false;
+        let optionsRes = await fetch(`${AUTH_URL}/auth/login/options`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ username })
         });
 
+        let resData = await optionsRes.json() as any;
+
         if (!optionsRes.ok) {
-            const errData = await optionsRes.json() as any;
-            if (errData.error === 'user_not_found') {
-                showStatus("Identity not found. To register a new Passkey, please use the CLI directly.");
-                throw new Error("Identity not found.");
+            if (resData.error === 'user_not_found') {
+                isRegistration = true;
+                showStatus("Account not found. Transitioning to Create Account...");
+                submitBtn.innerText = "REGISTER DEVICE...";
+                
+                optionsRes = await fetch(`${AUTH_URL}/auth/register/options`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ username })
+                });
+                
+                if (!optionsRes.ok) {
+                    throw new Error("Failed to initialize registration challenge.");
+                }
+                resData = await optionsRes.json() as any;
+            } else {
+                throw new Error(resData.error || "Failed to initialize security challenge.");
             }
-            throw new Error("Failed to initialize security challenge.");
         }
 
-        const { options, challengeToken, pkd_metadata } = await optionsRes.json() as any;
+        const { options, challengeToken, pkd_metadata } = resData;
         
         // Kathy Sierra UX Hook: Show empowering message before hardware prompt
         if (pkd_metadata) {
             showUXHook(pkd_metadata.title, pkd_metadata.hook);
         }
 
-        showStatus("Awaiting hardware confirmation...");
+        showStatus(isRegistration ? "Awaiting hardware registration..." : "Awaiting hardware confirmation...");
 
         // 2. Browser Passkey Prompt
         let asseResp;
         try {
-            asseResp = await startAuthentication({ optionsJSON: options });
+            if (isRegistration) {
+                asseResp = await startRegistration({ optionsJSON: options });
+            } else {
+                asseResp = await startAuthentication({ optionsJSON: options });
+            }
         } catch (error: any) {
-            throw new Error(`Hardware verification cancelled or failed: ${error.message}`);
+            throw new Error(`Hardware ${isRegistration ? 'registration' : 'verification'} cancelled or failed: ${error.message}`);
         }
 
         showStatus("Verifying cryptographic proof...");
 
-        // 3. Verify Authentication
-        const verifyRes = await fetch(`${AUTH_URL}/auth/login/verify`, {
+        // 3. Verify Authentication/Registration
+        const verifyEndpoint = isRegistration ? `${AUTH_URL}/auth/register/verify` : `${AUTH_URL}/auth/login/verify`;
+        const verifyRes = await fetch(verifyEndpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -169,7 +189,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         });
 
         if (!verifyRes.ok) {
-            throw new Error("Failed to verify hardware identity.");
+            throw new Error(`Failed to verify hardware identity.`);
         }
 
         const { access_token } = await verifyRes.json() as any;

--- a/apps/marketing/src/pages/verify.astro
+++ b/apps/marketing/src/pages/verify.astro
@@ -27,6 +27,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
           Enter the code displayed on your device and authenticate to link your identity.
         </p>
 
+        <p id="hardware-hint" class="hidden mb-6 text-xs text-ph-blue font-mono bg-ph-blue/5 p-4 border-l-2 border-ph-blue text-left leading-relaxed">
+          Looking for a security key. If you don't have one plugged in, you can scan the QR code with your phone's camera to sign in.
+        </p>
+
         <!-- Kathy Sierra UX Hook: Empowering Context -->
         <div id="ux-hook-container" class="hidden mb-6 text-left border-l-2 border-ph-blue pl-4 py-2 bg-ph-blue/5">
             <h3 id="ux-hook-title" class="text-ph-blue font-bold text-sm tracking-widest uppercase mb-1">Secure Identity</h3>
@@ -114,6 +118,8 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
   form?.addEventListener('submit', async (e) => {
     e.preventDefault();
+    const hardwareHint = document.getElementById('hardware-hint');
+    if (hardwareHint) hardwareHint.classList.remove('hidden');
     const formData = new FormData(form);
     const user_code = formData.get('user_code') as string;
     const username = formData.get('username') as string;


### PR DESCRIPTION
## Fix Summary
This PR implements the Web Registration Pivot as described in Issue #205. If the login options API returns a `user_not_found` error, the UI state smoothly transitions into a "Create Account" flow. It fetches registration options and executes `startRegistration` instead of `startAuthentication`, utilizing standard language for the workflow.

## Security Review
- Ensured WebAuthn startRegistration properly passes through hardware authentication checks.
- Safely transitions states by reading `user_not_found` error explicitly before transitioning, preventing bypass vulnerabilities.
- Maintains expected hardware checks for device authorization.

## DORA Metrics
- **Estimated Complexity Tier (ECT):** 1
- Task was contained within the marketing application UI component to redirect to correct registration flows.

Closes #205