### PR TITLE
fix(ci): remediate Containerfile.bridge space exhaustion

### DIFF
--- a/Containerfile.bridge
+++ b/Containerfile.bridge
@@ -6,6 +6,8 @@
 # License: FSL-1.1
 # Purpose: Zero-Host execution environment for Revit-to-Rust Interop.
 # Why: Multi-stage build (ADR-0017) ensures isolation of compilation and test environments.
+# Traceability: Issue #258
+# Last Updated: 2026-06-16
 # ========================================================================
 
 # Stage 1: Rust Builder (Metadata Core)
@@ -19,10 +21,19 @@ RUN cd packages/pkd-core && \
     if [ "$BUILD_MODE" = "release" ]; then cargo build --release; else cargo build; fi
 
 # Stage 2: .NET SDK (Revit Bridge Integration Tests)
-FROM public.ecr.aws/sam/build-dotnet8@sha256:d234c2e83b9f9cf1208f154aa4eb5df5ff3b5f74f12782afb8062ff31ee83174 AS dotnet-tester
+FROM public.ecr.aws/docker/library/debian@sha256:35ae959f6e83ffb465e7614d27b4fddd28288caa551fbca2798367567cce80d3 AS dotnet-tester
 ARG BUILD_MODE=debug
 ENV BUILD_MODE=$BUILD_MODE
 WORKDIR /work
+
+# Install dependencies and .NET 8 SDK on Debian Bookworm
+RUN apt-get update && apt-get install -y wget gpg && \
+    wget https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb && \
+    apt-get update && apt-get install -y dotnet-sdk-8.0 && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY . .
 
 # Copy the native core binary into the expected location for MSBuild $(RustTargetDir)

--- a/docs/governance/audits/issue-258.md
+++ b/docs/governance/audits/issue-258.md
@@ -1,0 +1,40 @@
+<!-- ========================================================================
+ * Project: Pharos Kitchen Design (Project Prism)
+ * Component: Governance / Audits
+ * File: docs/governance/audits/issue-258.md
+ * Author: Pharos Auditor (via Gemini CLI)
+ * License: FSL-1.1 (See LICENSE file for details)
+ * Purpose: Crucible Audit for Issue #258
+ * Traceability: Issue #258
+ * Last Updated: 2026-06-16
+ * ======================================================================== -->
+
+# ⚔️ Pharos Crucible Audit: Issue #258
+
+## 📋 Audit Overview
+- **Task ID**: Issue #258
+- **Description**: Remediate CI Disk Exhaustion in Containerfile.bridge by standardizing on Debian base image.
+- **Auditor**: Pharos Auditor (Senior Staff Engineer / Crucible Audit Engine)
+- **Status**: 🟢 PHAROS GREEN
+
+## 🔍 Verification Checklist
+- [x] **ADR-0014 Parity**: Base image standardized to `public.ecr.aws/docker/library/debian:bookworm` for compilation and test environment parity.
+- [x] **No Lambda Tools Leak**: SAM build dotnet image has been removed, resolving CI disk exhaustion and eliminating extra unused tools.
+- [x] **File Prologues**: Verified that `Containerfile.bridge` has a standardized FSL-1.1 prologue pointing to Issue #258.
+- [x] **Workspace Integrity**: Verified by running `scripts/pulse.sh --slice bridge` inside the container. All 19 tests passed successfully.
+
+## 🛠️ Evidence & Verification
+- **Command Output (Bridge Test Run)**:
+```bash
+scripts/pulse.sh --slice bridge
+🚀 [Slice: BRIDGE] Verifying .NET Revit Bridge & Handshake...
+...
+Passed!  - Failed:     0, Passed:    19, Skipped:     0, Total:    19, Duration: 2 s - Pkd.RevitBridge.Tests.dll (net8.0)
+✅ [Slice: BRIDGE] Verified.
+```
+
+## 📝 Auditor's Remarks
+The transition of `Containerfile.bridge` to Debian Bookworm successfully aligns it with other Docker files (like `Containerfile.pulse` stage 7). Installing `dotnet-sdk-8.0` directly from the Microsoft package repository ensures standard, clean environment setup, avoiding CI disk exhaustion issues associated with the SAM build images. No lambda tools or unnecessary files are leaked.
+
+---
+**Verdict**: 🟢 PHAROS GREEN


### PR DESCRIPTION
## Summary
This PR implements Issue #258, replacing the bloated `public.ecr.aws/sam/build-dotnet8` base image in `Containerfile.bridge` with standard Debian Bookworm and installing `dotnet-sdk-8.0` directly. This eliminates the `amazon.lambda.tools` dependency and resolves `no space left on device` build failures on GitHub Actions runners.

## Changes
- **Containerfile.bridge**: Changed `dotnet-tester` base image to Debian Bookworm.
- **Dependencies**: Added standard Debian package manager repository configuration for Microsoft's .NET SDK.
- **Documentation**: Updated prologues to trace Issue #258.

## Verification
- Verified with `./scripts/pulse.sh --slice bridge` inside Podman. All 19 tests passed.
- Crucible Audit completed with **🟢 PHAROS GREEN** verdict.

## ⚔️ The Pharos Crucible (Audit Log)

<!-- ========================================================================
 * Project: Pharos Kitchen Design (Project Prism)
 * Component: Governance / Audits
 * File: docs/governance/audits/issue-258.md
 * Author: Pharos Auditor (via Gemini CLI)
 * License: FSL-1.1 (See LICENSE file for details)
 * Purpose: Crucible Audit for Issue #258
 * Traceability: Issue #258
 * Last Updated: 2026-06-16
 * ======================================================================== -->

# ⚔️ Pharos Crucible Audit: Issue #258

## 📋 Audit Overview
- **Task ID**: Issue #258
- **Description**: Remediate CI Disk Exhaustion in Containerfile.bridge by standardizing on Debian base image.
- **Auditor**: Pharos Auditor (Senior Staff Engineer / Crucible Audit Engine)
- **Status**: 🟢 PHAROS GREEN

## 🔍 Verification Checklist
- [x] **ADR-0014 Parity**: Base image standardized to `public.ecr.aws/docker/library/debian:bookworm` for compilation and test environment parity.
- [x] **No Lambda Tools Leak**: SAM build dotnet image has been removed, resolving CI disk exhaustion and eliminating extra unused tools.
- [x] **File Prologues**: Verified that `Containerfile.bridge` has a standardized FSL-1.1 prologue pointing to Issue #258.
- [x] **Workspace Integrity**: Verified by running `scripts/pulse.sh --slice bridge` inside the container. All 19 tests passed successfully.

## 🛠️ Evidence & Verification
- **Command Output (Bridge Test Run)**:
```bash
scripts/pulse.sh --slice bridge
🚀 [Slice: BRIDGE] Verifying .NET Revit Bridge & Handshake...
...
Passed!  - Failed:     0, Passed:    19, Skipped:     0, Total:    19, Duration: 2 s - Pkd.RevitBridge.Tests.dll (net8.0)
✅ [Slice: BRIDGE] Verified.
```

## 📝 Auditor's Remarks
The transition of `Containerfile.bridge` to Debian Bookworm successfully aligns it with other Docker files (like `Containerfile.pulse` stage 7). Installing `dotnet-sdk-8.0` directly from the Microsoft package repository ensures standard, clean environment setup, avoiding CI disk exhaustion issues associated with the SAM build images. No lambda tools or unnecessary files are leaked.

---
**Verdict**: 🟢 PHAROS GREEN