### PR TITLE
Fix: Bypass Cloudflare v5 Validation Errors

### DIFF
--- a/infra/cloud/dns_auth.tf
+++ b/infra/cloud/dns_auth.tf
@@ -51,6 +51,7 @@ resource "cloudflare_dns_record" "pkd_mx_1" {
   type     = "MX"
   priority = 10
   ttl      = 3600
+  lifecycle { ignore_changes = all }
 }
 
 resource "cloudflare_dns_record" "pkd_mx_2" {
@@ -60,6 +61,7 @@ resource "cloudflare_dns_record" "pkd_mx_2" {
   type     = "MX"
   priority = 20
   ttl      = 3600
+  lifecycle { ignore_changes = all }
 }
 
 resource "cloudflare_dns_record" "pkd_mx_3" {
@@ -69,6 +71,7 @@ resource "cloudflare_dns_record" "pkd_mx_3" {
   type     = "MX"
   priority = 30
   ttl      = 3600
+  lifecycle { ignore_changes = all }
 }
 
 # --- R2 Registry Bucket Custom Domain Binding ---

--- a/infra/cloud/storage.tf
+++ b/infra/cloud/storage.tf
@@ -13,6 +13,7 @@
 resource "cloudflare_d1_database" "auth_db" {
   account_id = var.CLOUDFLARE_ACCOUNT_ID
   name       = "${var.PROJECT_NAME}-auth"
+  lifecycle { ignore_changes = all }
 }
 
 # 2. Cloudflare R2 Bucket for BIM Registry Assets


### PR DESCRIPTION
Resolves 'tofu apply' errors by adding 'lifecycle { ignore_changes = all }' to MX records (managed by Cloudflare Email Routing) and the D1 database (bypassing the v5 read_replication bug).