### PR TITLE
fix(infra): restrict CORS allowed headers from wildcard to specific headers (#275)

### DIFF
--- a/docs/governance/audits/issue-275.md
+++ b/docs/governance/audits/issue-275.md
@@ -1,0 +1,57 @@
+<!-- ========================================================================
+ * Project: Pharos Kitchen Design (Project Prism)
+ * Component: Governance / Audit Log
+ * File: issue-275.md
+ * Author: Junie AI (JetBrains)
+ * License: FSL-1.1 (See LICENSE file for details)
+ * Purpose: Audit validation log for Issue #275.
+ * Traceability: Issue #275, ADR-0039, ADR-0051
+ * Last Updated: 2026-06-22
+ * ======================================================================== -->
+
+# Audit Validation Log — Issue #275
+
+**Issue**: Configure Production-Only CORS Rules for Cloudflare R2 Registry Storage
+**Date**: 2026-06-22
+**Author**: Junie AI (Builder Agent — PHAROS_DEV_CORE)
+**Traceability**: ADR-0039, ADR-0051
+
+---
+
+## Changes Summary
+
+| File | Change |
+|------|--------|
+| `infra/cloud/storage.tf` | Added `cloudflare_r2_bucket_cors.registry_bucket_cors` resource with production-only origins (`https://iamrichardd.com`, `https://*.iamrichardd.com`). Updated file prologue (Traceability: Issue #275, Last Updated: 2026-06-22). |
+
+## CORS Configuration Details
+
+- **Resource**: `cloudflare_r2_bucket_cors.registry_bucket_cors`
+- **Bucket**: `cloudflare_r2_bucket.registry_bucket` (pkd-prism-registry)
+- **Rule ID**: `ProductionOnlyAccess`
+- **Allowed Methods**: `GET`, `OPTIONS`
+- **Allowed Origins**: `https://iamrichardd.com`, `https://*.iamrichardd.com`
+- **Allowed Headers**: `*`
+- **Max Age**: 86400 seconds (24 hours)
+
+## Crucible Decision
+
+**Option 1 (Hardcoded Production-Only CORS)** was promoted as the winner. This aligns with the Shift-Left Security directive — production storage never allows localhost traffic. Local registry serving (Issue #277) resolves local development loading.
+
+## Verification Checks
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| OpenTofu `fmt -check` on `storage.tf` | ✅ PASS | `storage.tf` not flagged by formatter (pre-existing `oidc.tf` formatting issue unrelated to this change). |
+| File prologue updated | ✅ PASS | Traceability includes Issue #275; Last Updated set to 2026-06-22. |
+| CORS resource references existing bucket | ✅ PASS | `bucket_name` references `cloudflare_r2_bucket.registry_bucket.name`. |
+| Production-only origins enforced | ✅ PASS | No localhost, staging, or wildcard-all origins present. |
+
+## Compliance
+
+- **ADR-0039**: Infrastructure changes follow IaC-first provisioning via OpenTofu.
+- **ADR-0051**: Security-sensitive configuration hardcoded to production values; no variable injection surface.
+
+---
+
+**Status**: 🟢 PHAROS GREEN

--- a/infra/cloud/storage.tf
+++ b/infra/cloud/storage.tf
@@ -35,7 +35,7 @@ resource "cloudflare_r2_bucket_cors" "registry_bucket_cors" {
       allowed = {
         methods = ["GET", "OPTIONS"]
         origins = ["https://iamrichardd.com", "https://*.iamrichardd.com"]
-        headers = ["*"]
+        headers = ["Content-Type", "Range"]
       }
     }
   ]

--- a/infra/cloud/storage.tf
+++ b/infra/cloud/storage.tf
@@ -5,8 +5,8 @@
  * Author: Richard D. (https://github.com/iamrichardd)
  * License: FSL-1.1 (See LICENSE file for details)
  * Purpose: Cloudflare D1 database and R2 bucket provisioning.
- * Traceability: ADR 0021, Issue #5, Issue #254
- * Last Updated: 2026-06-17
+ * Traceability: ADR 0021, Issue #5, Issue #254, Issue #275
+ * Last Updated: 2026-06-22
  * ======================================================================== */
 
 # 1. Cloudflare D1 Database for Auth Bridge
@@ -21,4 +21,22 @@ resource "cloudflare_r2_bucket" "registry_bucket" {
   account_id = var.CLOUDFLARE_ACCOUNT_ID
   name       = "${var.PROJECT_NAME}-registry"
   location   = "WNAM" # Western North America (Low latency for primary targets)
+}
+
+# 3. Production-Only CORS Rules for R2 Registry Bucket
+resource "cloudflare_r2_bucket_cors" "registry_bucket_cors" {
+  account_id  = var.CLOUDFLARE_ACCOUNT_ID
+  bucket_name = cloudflare_r2_bucket.registry_bucket.name
+
+  rules = [
+    {
+      id              = "ProductionOnlyAccess"
+      max_age_seconds = 86400
+      allowed = {
+        methods = ["GET", "OPTIONS"]
+        origins = ["https://iamrichardd.com", "https://*.iamrichardd.com"]
+        headers = ["*"]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Restricts the CORS `allowed_headers` on the R2 registry bucket from a wildcard (`["*"]`) to only the specific headers the application needs (`["Content-Type", "Range"]`), reducing the attack surface in line with the Shift-Left Security directive.

## Changes

- **`infra/cloud/storage.tf`**: Replaced `headers = ["*"]` with `headers = ["Content-Type", "Range"]` in the `cloudflare_r2_bucket_cors` resource's CORS rules.

## Motivation

A code review flagged that wildcarding all headers in the CORS configuration unnecessarily expands the attack surface. Since the BIM registry asset access only requires `Content-Type` and `Range` headers, restricting to these specific headers is a targeted security hardening measure.

## Traceability

- Closes #275
- Related: ADR 0021, Issue #254