### PR TITLE
feat: add --registry-target flag and PHAROS_REGISTRY_TARGET env to pkd registry #276

### DIFF
--- a/apps/marketing/src/content/roadmap.toon
+++ b/apps/marketing/src/content/roadmap.toon
@@ -3,12 +3,12 @@
  * Component: Marketing / Content
  * File: roadmap.toon
  * Purpose: Automated reflection of authoritative internal logs.
- * Last Synced: 2026-06-23T15:58:28.492Z
+ * Last Synced: 2026-06-23T17:28:28.451Z
  * ======================================================================== */
 
 title: Pharos System Roadmap
 type: roadmap
-lastSynced: 2026-06-23T15:58:28.492Z
+lastSynced: 2026-06-23T17:28:28.451Z
 
 items[66]{id, name, status, phase, tag, description}:
   "275", "Configure Production-Only CORS Rules for Cloudflare R2 Registry Storage", "Deployed", "Sprint 5.04", "CORE", "Enforced production-only origins and restricted allowed headers to Content-Type and Range to minimize attack surface. Verified 🟢 PHAROS GREEN."

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -5,7 +5,7 @@
  * Author: Richard D. (https://github.com/iamrichardd)
  * License: FSL-1.1 (See LICENSE file for details)
  * Purpose: Formal command reference for the Pharos Kitchen Design CLI (pkd).
- * Traceability: Issue #10, Issue #12, Issue #78, Issue #81, ADR-0006
+ * Traceability: Issue #10, Issue #12, Issue #78, Issue #81, ADR-0006, Issue #276
  * ======================================================================== -->
 
 # Pharos Kitchen Design CLI (pkd) Reference Guide
@@ -74,7 +74,12 @@ Metadata and engine operations.
 
 ### `pkd registry`
 Distribution lifecycle management for the Pharos Registry (Requires `OEM` or `ADMIN` role for mutation).
-- **`bake --source <PATH> --output <PATH> [--shard-id <ID>]`**: Transforms raw JSON shards into a compressed Zstd archive and Tantivy index.
+
+#### Global Options
+- **`--registry-target <PATH>`** (env: `PHAROS_REGISTRY_TARGET`): Sets a default target directory for registry output operations. When specified, subcommands such as `bake` will use this path as a fallback if their own `--output` flag is omitted.
+
+#### Subcommands
+- **`bake --source <PATH> [--output <PATH>] [--shard-id <ID>]`**: Transforms raw JSON shards into a compressed Zstd archive and Tantivy index. If `--output` is omitted, the value of `--registry-target` (or `PHAROS_REGISTRY_TARGET`) is used. An error is raised if neither is provided.
 - **`verify --path <PATH> [--remote] [--hash <HASH>]`**: Performs deep integrity checks on local or remote registry artifacts.
 - **`push --source <PATH> --shard-id <ID>`**: Promotes baked artifacts to the authoritative CDN (R2). Enforces the **Organization Sentinel** to ensure OEMs only push to their assigned shards.
 - **`pulse [--env <REALM>]`**: High-rigor system health and synchronization check. Ensures local cache parity with remote truth.

--- a/packages/pkd-cli/src/main.rs
+++ b/packages/pkd-cli/src/main.rs
@@ -228,7 +228,9 @@ async fn main() -> Result<()> {
                 }
             },
             Commands::Registry(args) => {
-                registry_mgr.handle(args.action).await?;
+                registry_mgr
+                    .handle(args.action, args.registry_target)
+                    .await?;
             }
             Commands::Gov { action } => match action {
                 GovCommands::Lint => {

--- a/packages/pkd-cli/src/registry.rs
+++ b/packages/pkd-cli/src/registry.rs
@@ -5,7 +5,7 @@
  * Author: Richard D. (https://github.com/iamrichardd)
  * License: FSL-1.1 (See LICENSE file for details)
  * Purpose: Distribution lifecycle management for the Pharos Registry.
- * Traceability: Issue #126, ADR-0026, ADR-0027
+ * Traceability: Issue #126, ADR-0026, ADR-0027, Issue #276
  * ======================================================================== */
 
 use crate::auth::AuthManager;
@@ -18,6 +18,10 @@ use std::path::PathBuf;
 
 #[derive(Args, Debug)]
 pub struct RegistryArgs {
+    /// Default target directory for registry output (overrides per-command defaults)
+    #[arg(long, env = "PHAROS_REGISTRY_TARGET", global = true)]
+    pub registry_target: Option<PathBuf>,
+
     #[command(subcommand)]
     pub action: RegistryCommands,
 }
@@ -29,9 +33,9 @@ pub enum RegistryCommands {
         /// Source directory containing sharded JSON files
         #[arg(short, long)]
         source: PathBuf,
-        /// Output directory for the compiled artifacts
+        /// Output directory for the compiled artifacts (falls back to --registry-target)
         #[arg(short, long)]
-        output: PathBuf,
+        output: Option<PathBuf>,
         /// Optional shard-id for incremental baking
         #[arg(long)]
         shard_id: Option<String>,
@@ -84,13 +88,25 @@ impl RegistryManager {
         Self { auth_mgr, env }
     }
 
-    pub async fn handle(&self, action: RegistryCommands) -> Result<()> {
+    pub async fn handle(
+        &self,
+        action: RegistryCommands,
+        registry_target: Option<PathBuf>,
+    ) -> Result<()> {
         match action {
             RegistryCommands::Bake {
                 source,
                 output,
                 shard_id,
-            } => self.bake(source, output, shard_id).await,
+            } => {
+                let resolved_output = output.or(registry_target).ok_or_else(|| {
+                    anyhow!(
+                        "No output directory specified. Provide --output on the bake command \
+                         or --registry-target on the registry command (or set PHAROS_REGISTRY_TARGET)."
+                    )
+                })?;
+                self.bake(source, resolved_output, shard_id).await
+            }
             RegistryCommands::Verify { path, remote, hash } => {
                 self.verify(path, remote, hash).await
             }
@@ -473,6 +489,87 @@ mod tests {
             .with_mock_token("access_token", "acc")
             .with_mock_token("id_token", &mock_token)
     }
+
+    // --- Registry Target Override Tests (Issue #276) ---
+
+    #[tokio::test]
+    async fn test_bake_should_use_output_when_both_output_and_registry_target_provided() {
+        let auth_mgr = setup_mock_auth(PharosRole::Admin, None);
+        let mgr = RegistryManager::new(auth_mgr, PharosEnv::Dev);
+        let source_dir = TempDir::new().unwrap();
+        let output_dir = TempDir::new().unwrap();
+        let target_dir = TempDir::new().unwrap();
+
+        // When both --output and --registry-target are provided, --output wins
+        let action = RegistryCommands::Bake {
+            source: source_dir.path().to_path_buf(),
+            output: Some(output_dir.path().to_path_buf()),
+            shard_id: None,
+        };
+
+        let result = mgr
+            .handle(action, Some(target_dir.path().to_path_buf()))
+            .await;
+        // Bake succeeds with empty source; artifacts land in output_dir, not target_dir
+        assert!(result.is_ok());
+        assert!(
+            output_dir.path().join("search-index.tar.zst").exists(),
+            "Artifacts should be written to --output, not --registry-target"
+        );
+        assert!(
+            !target_dir.path().join("search-index.tar.zst").exists(),
+            "--registry-target directory should remain empty when --output is provided"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bake_should_fallback_to_registry_target_when_output_omitted() {
+        let auth_mgr = setup_mock_auth(PharosRole::Admin, None);
+        let mgr = RegistryManager::new(auth_mgr, PharosEnv::Dev);
+        let source_dir = TempDir::new().unwrap();
+        let target_dir = TempDir::new().unwrap();
+
+        let action = RegistryCommands::Bake {
+            source: source_dir.path().to_path_buf(),
+            output: None,
+            shard_id: None,
+        };
+
+        let result = mgr
+            .handle(action, Some(target_dir.path().to_path_buf()))
+            .await;
+        // Bake should succeed, writing artifacts into registry-target
+        assert!(result.is_ok());
+        assert!(
+            target_dir.path().join("search-index.tar.zst").exists(),
+            "Artifacts should fall back to --registry-target when --output is omitted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bake_should_error_when_neither_output_nor_registry_target_provided() {
+        let auth_mgr = setup_mock_auth(PharosRole::Admin, None);
+        let mgr = RegistryManager::new(auth_mgr, PharosEnv::Dev);
+        let source_dir = TempDir::new().unwrap();
+
+        let action = RegistryCommands::Bake {
+            source: source_dir.path().to_path_buf(),
+            output: None,
+            shard_id: None,
+        };
+
+        let result = mgr.handle(action, None).await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("No output directory specified"),
+            "Should fail with clear error when neither --output nor --registry-target is provided"
+        );
+    }
+
+    // --- Push Authorization Tests ---
 
     #[tokio::test]
     async fn test_should_allow_push_when_admin_authenticated() {


### PR DESCRIPTION
## Summary

This changeset introduces a global `--registry-target` flag on the `pkd registry` command group, backed by the `PHAROS_REGISTRY_TARGET` environment variable. The flag establishes a default output directory for registry operations, eliminating the need to pass `--output` on every `bake` invocation when a consistent local target is preferred.

The `Bake` subcommand's `--output` parameter is relaxed from required to optional. When omitted, the resolver falls back to `--registry-target`; when both are supplied, the explicit `--output` takes precedence. If neither is provided, the CLI raises a descriptive error at the point of resolution — preserving the fail-fast contract without silently defaulting to an arbitrary path.

## Changes

### `packages/pkd-cli/src/registry.rs`
- Added `registry_target: Option<PathBuf>` to `RegistryArgs`, annotated with `#[arg(long, env = "PHAROS_REGISTRY_TARGET", global = true)]`.
- Relaxed `Bake::output` from `PathBuf` to `Option<PathBuf>`.
- Implemented deterministic resolution in `RegistryManager::handle()`: `output.or(registry_target).ok_or_else(...)`.
- Added three integration tests covering the override, fallback, and missing-path error scenarios.

### `packages/pkd-cli/src/main.rs`
- Threads `args.registry_target` through to `RegistryManager::handle()` at the command dispatch site.

### `docs/CLI_REFERENCE.md`
- Documented the new `--registry-target` global option under a dedicated "Global Options" section within `pkd registry`.
- Updated the `bake` subcommand signature to reflect the optional `--output` with fallback semantics.

### `apps/marketing/src/content/roadmap.toon`
- Resolved a trivial sync timestamp conflict introduced during rebase onto the latest `main`.

## Verification

- `cargo build --package pkd` compiles cleanly with zero warnings.
- All 7 registry module tests pass (`cargo test --package pkd -- registry`), including the 3 new tests for Issue #276:
  - `test_bake_should_use_output_when_both_output_and_registry_target_provided`
  - `test_bake_should_fallback_to_registry_target_when_output_omitted`
  - `test_bake_should_error_when_neither_output_nor_registry_target_provided`

## ⚔️ The Pharos Crucible (Audit Log)

_Pending post-merge audit._

Closes #276
